### PR TITLE
Update score_screen.dart : use numOfCorrectAns instead of correctAns

### DIFF
--- a/lib/screens/score/score_screen.dart
+++ b/lib/screens/score/score_screen.dart
@@ -25,7 +25,7 @@ class ScoreScreen extends StatelessWidget {
               ),
               Spacer(),
               Text(
-                "${_qnController.correctAns * 10}/${_qnController.questions.length * 10}",
+                "${_qnController.numOfCorrectAns * 10}/${_qnController.questions.length * 10}",
                 style: Theme.of(context)
                     .textTheme
                     .headline4


### PR DESCRIPTION
The screen previously used correctAns in Question controller, which is equal to the last question correct answer index. 
But we want to use the total number of correct answers represented by numOfCorrectAns in question controller.